### PR TITLE
Seek to disambiguate maintainer/developer/issue-reporter

### DIFF
--- a/docs/duplicate.md
+++ b/docs/duplicate.md
@@ -2,6 +2,6 @@
 
 Typically applied to an issue that is a duplicate of another.
 
-It's not uncommon for multiple issues by different developers to reference the same problem.
+It's not uncommon for multiple issues by different authors to reference the same problem.
 Maintainers will prefer to track work on a single issue, and will mark others as a duplicate.
 It is good practice by the maintainer to link from the duplicate issues to the original issue.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 This site adds additional context to GitHub Issue labels.
 
 The intention here is to be descriptive regarding the Open Source development process, not *prescriptive*.
-In other words it is an attempt to document how developer generally apply these labels, and not attempt to impose some kind of standard.
+In other words it is an attempt to document how maintainers generally apply these labels, and not attempt to impose some kind of standard.
 
 
 !!! note

--- a/docs/wontfix.md
+++ b/docs/wontfix.md
@@ -9,7 +9,7 @@ This label may also be used if the maintainer considers the issue to not be a pr
 Perhaps the likelihood of the issue occurring is just too remote, or requires exotic conditions to replicate.
 It could also be that the maintainer is simply unable to fix the issue because it is out of their hands, and the root cause is in software they don't control.
 
-## What can developers do?
+## What can issue reporters do?
 
 It's possible that the maintainer hasn't fully appreciated the issue in question.
 Perhaps it seems a remote theoretical possibility to them, but is more likely than they appreciate.


### PR DESCRIPTION
Some of the wording seems to imagine that the person reporting an issue is a "developer" -- this can often not be the case; plenty of repositories contain code for applications that aren't aimed at developers, and the users of those applications are still encouraged to report problems via GitHub. I suspect this site will be even more useful to such projects.

I've also modified one instance of developer being used to mean maintainer.

The X/Y problem article seems to lean heavily into "folk reporting are developers"; I've left that alone as I guess it's more common to be the case there; but perhaps it's worth us rethinking the wording there so it's also helpful to maintainers of repositories where the target user base isn't other developers.