### PR TITLE
docs: add additional links to the articles

### DIFF
--- a/docs/articles/minimal-reproducible-example.md
+++ b/docs/articles/minimal-reproducible-example.md
@@ -30,3 +30,7 @@ Perhaps the problem occurs only under certain conditions or with data that you c
 Or it could be that it is very difficult to narrow down the problematic code.
 
 Maintainers will understand this. So don't worry if you can produce a MRE.
+
+## Links
+
+- [Craft Minimal Bug Reports](https://matthewrocklin.com/minimal-bug-reports.html) by Matthew Rocklin

--- a/docs/articles/xy-problem.md
+++ b/docs/articles/xy-problem.md
@@ -42,3 +42,4 @@ It may be a genuine use case you hadn't considered or it may be the XY problem. 
 
 - [XY Problem on Wikipedia](https://en.wikipedia.org/wiki/XY_problem)
 - [xyproblem.info](https://xyproblem.info/)
+- [XY Problem on StackExchange](https://meta.stackexchange.com/questions/66377/what-is-the-xy-problem)


### PR DESCRIPTION
This PR adds two links:

1. The [Craft Minimal Bug Reports](https://matthewrocklin.com/minimal-bug-reports.html) by Matthew Rocklin should be very helpful for folks working/using data libraries. This post also includes a [link](https://stackoverflow.com/help/minimal-reproducible-example) to the StackOverflow guide on how to create a Minimal, Reproducible Example.

2. A [question](https://meta.stackexchange.com/questions/66377/what-is-the-xy-problem) on Meta StackExchange on the XY Problem, the answers include some helpful tips on how to avoid it and also links to the definition in other languages (helpful for non-native English speakers)
