### PR TITLE
docs(mre article): add link to the sscce

### DIFF
--- a/docs/articles/minimal-reproducible-example.md
+++ b/docs/articles/minimal-reproducible-example.md
@@ -34,3 +34,4 @@ Maintainers will understand this. So don't worry if you can produce a MRE.
 ## Links
 
 - [Craft Minimal Bug Reports](https://matthewrocklin.com/minimal-bug-reports.html) by Matthew Rocklin
+- [The Short, Self Contained, Correct Example](http://www.sscce.org/)


### PR DESCRIPTION
Add a link to the [Short, Self Contained, Correct Example](http://www.sscce.org/) in the MRE article.

Some of the advice is perhaps a bit dated or overly-prescriptive, but in general I think a good concise guide.